### PR TITLE
Verify invite owner claims with signed AppKeys

### DIFF
--- a/rust/crates/nostr-double-ratchet/src/app_keys.rs
+++ b/rust/crates/nostr-double-ratchet/src/app_keys.rs
@@ -74,6 +74,17 @@ impl VerifiedAppKeysIndex {
             current.created_at_secs = created_at_secs;
             current.candidates.clear();
         }
+        // AppKeys publishers may re-encrypt labels or rotate non-authoritative
+        // tags without advancing the roster timestamp. Keep only one exact
+        // event for an equivalent authorization roster, while retaining
+        // genuinely different equal-time rosters so membership fails closed.
+        if current.candidates.values().any(|candidate| {
+            candidate
+                .app_keys
+                .has_equivalent_authorization_roster(&app_keys)
+        }) {
+            return Ok(false);
+        }
         Ok(current
             .candidates
             .insert(event.id, AppKeysAuthorizationCandidate { event, app_keys })
@@ -227,6 +238,16 @@ impl AppKeys {
 
     pub fn get_all_devices(&self) -> Vec<DeviceEntry> {
         self.devices.values().cloned().collect()
+    }
+
+    fn has_equivalent_authorization_roster(&self, other: &Self) -> bool {
+        self.devices.len() == other.devices.len()
+            && self.devices.iter().all(|(pubkey, device)| {
+                other
+                    .devices
+                    .get(pubkey)
+                    .is_some_and(|other_device| other_device.created_at == device.created_at)
+            })
     }
 
     pub fn set_device_labels(

--- a/rust/crates/nostr-double-ratchet/src/app_keys.rs
+++ b/rust/crates/nostr-double-ratchet/src/app_keys.rs
@@ -6,7 +6,7 @@ use nostr::{
     UnsignedEvent,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use uuid::Uuid;
 
 pub const APP_KEYS_SNAPSHOT_KIND: u32 = 37368;
@@ -15,6 +15,131 @@ pub const APP_KEYS_FACT_TYPE: &str = "app_keys_roster_snapshot";
 pub const APP_KEYS_ENCRYPTED_DEVICE_LABELS_FACT: &str = "encrypted_device_labels";
 pub const APP_KEYS_ENCRYPTED_DEVICE_LABELS_SCHEMA: u64 = 1;
 pub const APP_KEYS_OWNER_PUBKEY_FACT: &str = "owner_pubkey";
+const APP_KEYS_AUTHORIZATION_MAX_EVENT_BYTES: usize = 64 * 1024;
+const APP_KEYS_AUTHORIZATION_MAX_DEVICES: usize = 64;
+const APP_KEYS_AUTHORIZATION_MAX_FUTURE_SKEW_SECS: u64 = 5 * 60;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeviceMembership {
+    Authorized,
+    Excluded,
+    Missing,
+    Ambiguous,
+}
+
+#[derive(Debug, Clone)]
+struct AppKeysAuthorizationCandidate {
+    event: Event,
+    app_keys: AppKeys,
+}
+
+#[derive(Debug, Clone)]
+struct VerifiedAppKeysHead {
+    created_at_secs: u64,
+    candidates: BTreeMap<nostr::EventId, AppKeysAuthorizationCandidate>,
+}
+
+/// Canonical owner-signed AppKeys heads observed through normal event ingestion.
+///
+/// Newer snapshots replace older ones. Conflicting snapshots at the same second
+/// remain visible so security-sensitive membership checks can fail closed.
+#[derive(Debug, Clone, Default)]
+pub struct VerifiedAppKeysIndex {
+    heads: BTreeMap<PublicKey, VerifiedAppKeysHead>,
+}
+
+impl VerifiedAppKeysIndex {
+    pub fn ingest(&mut self, event: Event, now_secs: u64) -> Result<bool> {
+        let owner = event.pubkey;
+        let app_keys = app_keys_authorization_candidate(owner, &event, now_secs)?;
+        let created_at_secs = event.created_at.as_secs();
+        let Some(current) = self.heads.get_mut(&owner) else {
+            self.heads.insert(
+                owner,
+                VerifiedAppKeysHead {
+                    created_at_secs,
+                    candidates: BTreeMap::from([(
+                        event.id,
+                        AppKeysAuthorizationCandidate { event, app_keys },
+                    )]),
+                },
+            );
+            return Ok(true);
+        };
+
+        if created_at_secs < current.created_at_secs {
+            return Ok(false);
+        }
+        if created_at_secs > current.created_at_secs {
+            current.created_at_secs = created_at_secs;
+            current.candidates.clear();
+        }
+        Ok(current
+            .candidates
+            .insert(event.id, AppKeysAuthorizationCandidate { event, app_keys })
+            .is_none())
+    }
+
+    pub fn membership(&self, owner: PublicKey, device: PublicKey) -> DeviceMembership {
+        let Some(head) = self.heads.get(&owner) else {
+            return DeviceMembership::Missing;
+        };
+        let membership = head
+            .candidates
+            .values()
+            .map(|candidate| candidate.app_keys.get_device(&device).is_some())
+            .collect::<BTreeSet<_>>();
+        if membership.len() != 1 {
+            DeviceMembership::Ambiguous
+        } else if membership.contains(&true) {
+            DeviceMembership::Authorized
+        } else {
+            DeviceMembership::Excluded
+        }
+    }
+
+    pub fn events_for_owner(&self, owner: PublicKey) -> Vec<Event> {
+        self.heads
+            .get(&owner)
+            .map(|head| {
+                head.candidates
+                    .values()
+                    .map(|candidate| candidate.event.clone())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn events(&self) -> Vec<Event> {
+        self.heads
+            .values()
+            .flat_map(|head| {
+                head.candidates
+                    .values()
+                    .map(|candidate| candidate.event.clone())
+            })
+            .collect()
+    }
+
+    pub(crate) fn owners(&self) -> Vec<PublicKey> {
+        self.heads.keys().copied().collect()
+    }
+
+    pub(crate) fn head_created_at(&self, owner: PublicKey) -> Option<u64> {
+        self.heads.get(&owner).map(|head| head.created_at_secs)
+    }
+
+    pub(crate) fn app_keys_for_event(
+        &self,
+        owner: PublicKey,
+        event_id: nostr::EventId,
+    ) -> Option<AppKeys> {
+        self.heads
+            .get(&owner)
+            .and_then(|head| head.candidates.get(&event_id))
+            .map(|candidate| candidate.app_keys.clone())
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct DeviceEntry {
@@ -486,6 +611,49 @@ pub fn resolve_app_keys_owner_for_device(
 ) -> Result<Option<PublicKey>> {
     let app_keys = AppKeys::from_event(event)?;
     Ok(app_keys.get_device(&device_pubkey).map(|_| event.pubkey))
+}
+
+fn app_keys_authorization_candidate(
+    owner: PublicKey,
+    event: &Event,
+    now_secs: u64,
+) -> Result<AppKeys> {
+    if event.pubkey != owner {
+        return Err(Error::InvalidEvent(
+            "AppKeys authorization owner mismatch".to_string(),
+        ));
+    }
+    if event.created_at.as_secs()
+        > now_secs.saturating_add(APP_KEYS_AUTHORIZATION_MAX_FUTURE_SKEW_SECS)
+    {
+        return Err(Error::InvalidEvent(
+            "AppKeys authorization event is too far in the future".to_string(),
+        ));
+    }
+    if serde_json::to_vec(event)?.len() > APP_KEYS_AUTHORIZATION_MAX_EVENT_BYTES {
+        return Err(Error::InvalidEvent(
+            "AppKeys authorization event is too large".to_string(),
+        ));
+    }
+    let device_tags = event
+        .tags
+        .iter()
+        .filter(|tag| tag.as_slice().first().map(|value| value.as_str()) == Some("device"))
+        .collect::<Vec<_>>();
+    if device_tags.len() > APP_KEYS_AUTHORIZATION_MAX_DEVICES {
+        return Err(Error::InvalidEvent(
+            "AppKeys authorization roster has too many devices".to_string(),
+        ));
+    }
+    if device_tags.iter().any(|tag| {
+        let values = tag.as_slice();
+        values.len() < 3 || values[2].parse::<u64>().is_err()
+    }) {
+        return Err(Error::InvalidEvent(
+            "AppKeys authorization device tag is malformed".to_string(),
+        ));
+    }
+    AppKeys::from_event(event)
 }
 
 fn tag_values(event: &Event, name: &str) -> Vec<String> {

--- a/rust/crates/nostr-double-ratchet/src/lib.rs
+++ b/rust/crates/nostr-double-ratchet/src/lib.rs
@@ -24,9 +24,10 @@ pub mod wire;
 pub use app_keys::{
     build_app_keys_device_authorization_filter,
     encrypted_device_label_payloads_from_app_keys_event, is_app_keys_event,
-    resolve_app_keys_owner_for_device, AppKeys, DeviceEntry, DeviceLabels,
-    APP_KEYS_ENCRYPTED_DEVICE_LABELS_FACT, APP_KEYS_ENCRYPTED_DEVICE_LABELS_SCHEMA,
-    APP_KEYS_FACT_TYPE, APP_KEYS_OWNER_PUBKEY_FACT, APP_KEYS_SCHEMA, APP_KEYS_SNAPSHOT_KIND,
+    resolve_app_keys_owner_for_device, AppKeys, DeviceEntry, DeviceLabels, DeviceMembership,
+    VerifiedAppKeysIndex, APP_KEYS_ENCRYPTED_DEVICE_LABELS_FACT,
+    APP_KEYS_ENCRYPTED_DEVICE_LABELS_SCHEMA, APP_KEYS_FACT_TYPE, APP_KEYS_OWNER_PUBKEY_FACT,
+    APP_KEYS_SCHEMA, APP_KEYS_SNAPSHOT_KIND,
 };
 pub use device_link::{
     deterministic_link_invite_for_device, deterministic_link_invite_for_device_link_request,

--- a/rust/crates/nostr-double-ratchet/src/multi_device.rs
+++ b/rust/crates/nostr-double-ratchet/src/multi_device.rs
@@ -311,18 +311,6 @@ pub fn resolve_invite_owner_routing(
         };
     }
 
-    // A private invite is a bearer-capability link. Its owner claim is carried
-    // out-of-band in the link rather than discovered from relay AppKeys first.
-    if invite_purpose == Some("private") {
-        return InviteOwnerRoutingResolution {
-            owner_pubkey: claimed_owner_pubkey,
-            claimed_owner_pubkey,
-            verified_with_app_keys: false,
-            used_link_bootstrap_exception: false,
-            fell_back_to_device_identity: false,
-        };
-    }
-
     InviteOwnerRoutingResolution {
         owner_pubkey: device_pubkey,
         claimed_owner_pubkey,
@@ -473,7 +461,7 @@ mod tests {
     }
 
     #[test]
-    fn trusts_private_invite_owner_claim_without_appkeys() {
+    fn private_invite_owner_claim_falls_back_to_device_without_appkeys() {
         let device = Keys::generate().public_key();
         let owner = Keys::generate().public_key();
         let current_owner = Keys::generate().public_key();
@@ -481,9 +469,9 @@ mod tests {
         let resolved =
             resolve_invite_owner_routing(device, owner, Some("private"), current_owner, None);
 
-        assert_eq!(resolved.owner_pubkey, owner);
+        assert_eq!(resolved.owner_pubkey, device);
         assert!(!resolved.verified_with_app_keys);
-        assert!(!resolved.fell_back_to_device_identity);
+        assert!(resolved.fell_back_to_device_identity);
     }
 
     #[test]

--- a/rust/crates/nostr-double-ratchet/src/session_manager.rs
+++ b/rust/crates/nostr-double-ratchet/src/session_manager.rs
@@ -1,7 +1,7 @@
 use crate::{
-    AuthorizedDevice, DevicePubkey, DeviceRoster, DomainError, Error, Invite, InviteResponse,
-    InviteResponseEnvelope, MessageEnvelope, OwnerPubkey, ProtocolContext, Result,
-    RosterSnapshotDecision, Session, SessionState, UnixSeconds,
+    AuthorizedDevice, DeviceMembership, DevicePubkey, DeviceRoster, DomainError, Error, Invite,
+    InviteResponse, InviteResponseEnvelope, MessageEnvelope, OwnerPubkey, ProtocolContext, Result,
+    RosterSnapshotDecision, Session, SessionState, UnixSeconds, VerifiedAppKeysIndex,
 };
 use rand::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
@@ -14,6 +14,7 @@ pub struct SessionManager {
     local_device_pubkey: DevicePubkey,
     local_device_secret_key: [u8; 32],
     local_invite: Option<Invite>,
+    verified_peer_app_keys: VerifiedAppKeysIndex,
     users: BTreeMap<OwnerPubkey, UserRecord>,
 }
 
@@ -44,6 +45,8 @@ pub struct SessionManagerSnapshot {
     pub local_owner_pubkey: OwnerPubkey,
     pub local_device_pubkey: DevicePubkey,
     pub local_invite: Option<Invite>,
+    #[serde(default)]
+    pub verified_peer_app_keys_events: Vec<nostr::Event>,
     pub users: Vec<UserRecordSnapshot>,
 }
 
@@ -140,6 +143,7 @@ impl SessionManager {
             local_device_pubkey,
             local_device_secret_key,
             local_invite: None,
+            verified_peer_app_keys: VerifiedAppKeysIndex::default(),
             users: BTreeMap::new(),
         }
     }
@@ -157,6 +161,15 @@ impl SessionManager {
             .into());
         }
 
+        let mut verified_peer_app_keys = VerifiedAppKeysIndex::default();
+        for event in snapshot.verified_peer_app_keys_events {
+            let observed_at = event.created_at.as_secs();
+            // Invalid or corrupt persisted evidence fails closed. A stored event
+            // was already accepted at observation time, so restore validates it
+            // against its own timestamp rather than the current wall clock.
+            let _ = verified_peer_app_keys.ingest(event, observed_at);
+        }
+
         let users = snapshot
             .users
             .into_iter()
@@ -164,13 +177,40 @@ impl SessionManager {
             .map(|record| (record.owner_pubkey, record))
             .collect();
 
-        Ok(Self {
+        let mut manager = Self {
             local_owner_pubkey: snapshot.local_owner_pubkey,
             local_device_pubkey: snapshot.local_device_pubkey,
             local_device_secret_key,
             local_invite: snapshot.local_invite,
+            verified_peer_app_keys,
             users,
-        })
+        };
+
+        // Cached roster projections and authorization flags are not owner proof.
+        // Rebuild authorization from exact signed AppKeys evidence first, then
+        // promote only provisional claims covered by that evidence.
+        let restored_owners = manager.users.keys().copied().collect::<Vec<_>>();
+        for owner_pubkey in restored_owners.iter().copied() {
+            manager.recompute_authorization_for_owner(owner_pubkey);
+        }
+        let verified_owners = manager
+            .verified_peer_app_keys
+            .owners()
+            .into_iter()
+            .map(|owner| OwnerPubkey::from_bytes(owner.to_bytes()))
+            .collect::<Vec<_>>();
+        for owner_pubkey in verified_owners {
+            let now = owner_pubkey
+                .to_nostr()
+                .ok()
+                .and_then(|owner| manager.verified_peer_app_keys.head_created_at(owner))
+                .map(UnixSeconds)
+                .unwrap_or(UnixSeconds(0));
+            manager.reconcile_verified_claimed_devices(owner_pubkey, now);
+            manager.recompute_authorization_for_owner(owner_pubkey);
+        }
+
+        Ok(manager)
     }
 
     pub fn snapshot(&self) -> SessionManagerSnapshot {
@@ -178,6 +218,7 @@ impl SessionManager {
             local_owner_pubkey: self.local_owner_pubkey,
             local_device_pubkey: self.local_device_pubkey,
             local_invite: self.local_invite.clone(),
+            verified_peer_app_keys_events: self.verified_peer_app_keys.events(),
             users: self.users.values().map(UserRecord::snapshot).collect(),
         }
     }
@@ -216,12 +257,64 @@ impl SessionManager {
         self.apply_roster_for_owner_inner(self.local_owner_pubkey, roster, true)
     }
 
+    /// Observe a peer roster as an operational projection only.
+    ///
+    /// This method never grants a distinct device (`O != D`) authority to act
+    /// for the owner. Feed the exact signed event to
+    /// [`SessionManager::observe_peer_app_keys_event`] to establish that proof.
+    /// Observations naming the local owner are ignored; local roster changes
+    /// must use [`SessionManager::apply_local_roster`] or
+    /// [`SessionManager::replace_local_roster`].
     pub fn observe_peer_roster(
         &mut self,
         owner_pubkey: OwnerPubkey,
         roster: DeviceRoster,
     ) -> RosterSnapshotDecision {
+        if owner_pubkey == self.local_owner_pubkey {
+            return RosterSnapshotDecision::Stale;
+        }
         self.apply_roster_for_owner(owner_pubkey, roster)
+    }
+
+    /// Observe exact AppKeys evidence signed by a peer owner.
+    ///
+    /// A plain `DeviceRoster` is only an operational projection. Distinct
+    /// owner/device authorization (`O != D`) is granted only through this path.
+    pub fn observe_peer_app_keys_event(
+        &mut self,
+        event: nostr::Event,
+        observed_at: UnixSeconds,
+    ) -> Result<bool> {
+        let owner_nostr = event.pubkey;
+        let event_id = event.id;
+        let owner = OwnerPubkey::from_bytes(owner_nostr.to_bytes());
+        let created_at = UnixSeconds(event.created_at.as_secs());
+        if !self
+            .verified_peer_app_keys
+            .ingest(event, observed_at.get())?
+        {
+            return Ok(false);
+        }
+        let app_keys = self
+            .verified_peer_app_keys
+            .app_keys_for_event(owner_nostr, event_id)
+            .expect("successfully ingested AppKeys candidate must remain indexed");
+
+        let roster = DeviceRoster::new(
+            created_at,
+            app_keys
+                .get_all_devices()
+                .into_iter()
+                .map(|device| {
+                    AuthorizedDevice::new(
+                        DevicePubkey::from_bytes(device.identity_pubkey.to_bytes()),
+                        UnixSeconds(device.created_at),
+                    )
+                })
+                .collect(),
+        );
+        self.apply_roster_for_owner(owner, roster);
+        Ok(true)
     }
 
     pub fn observe_device_invite(
@@ -254,49 +347,16 @@ impl SessionManager {
 
         self.local_invite = Some(owned_invite);
 
-        let device_owner_pubkey = crate::owner_pubkey_from_device_pubkey(invitee_device_pubkey);
         let invitee_owner_pubkey = invitee_owner_pubkey.ok_or_else(|| {
             DomainError::InvalidState("invite response missing owner claim".to_string())
         })?;
-        let claimed_owner_pubkey =
-            (invitee_owner_pubkey != device_owner_pubkey).then_some(invitee_owner_pubkey);
-        let owner_pubkey = claimed_owner_pubkey
-            .filter(|claimed_owner_pubkey| {
-                self.users
-                    .get(claimed_owner_pubkey)
-                    .and_then(|user| user.roster.as_ref())
-                    .and_then(|roster| roster.get_device(&invitee_device_pubkey))
-                    .is_some()
-            })
-            .unwrap_or(device_owner_pubkey);
-        let should_seed_single_device_roster = owner_pubkey == device_owner_pubkey
-            && self
-                .users
-                .get(&owner_pubkey)
-                .and_then(|user| user.roster.as_ref())
-                .is_none();
-        let user = self.user_record_mut(owner_pubkey);
-        if should_seed_single_device_roster {
-            user.roster = Some(DeviceRoster::new(
-                ctx.now,
-                vec![AuthorizedDevice::new(invitee_device_pubkey, ctx.now)],
-            ));
-        }
-        let record = user.device_record_mut(invitee_device_pubkey, ctx.now);
-        record.claimed_owner_pubkey = claimed_owner_pubkey
-            .filter(|claimed_owner_pubkey| *claimed_owner_pubkey != owner_pubkey);
-        if should_seed_single_device_roster {
-            record.authorized = true;
-            record.is_stale = false;
-        }
-        record.invite_response_generated = true;
-        record.upsert_session(session, ctx.now);
 
-        Ok(Some(ProcessedInviteResponse {
-            owner_pubkey,
-            device_pubkey: invitee_device_pubkey,
-            claimed_owner_pubkey: record.claimed_owner_pubkey,
-        }))
+        Ok(Some(self.store_claimed_session(
+            invitee_owner_pubkey,
+            invitee_device_pubkey,
+            session,
+            ctx.now,
+        )))
     }
 
     pub fn prepare_send<R>(
@@ -530,6 +590,7 @@ impl SessionManager {
     where
         R: RngCore + CryptoRng,
     {
+        let owner_authorized_devices = self.authorized_devices_for_owner(sender_owner);
         let Some(user) = self.users.get_mut(&sender_owner) else {
             return Ok(None);
         };
@@ -540,6 +601,13 @@ impl SessionManager {
                 .devices
                 .get_mut(&device_pubkey)
                 .expect("device key collected from map");
+
+            let has_owner_binding = crate::owner_pubkey_from_device_pubkey(device_pubkey)
+                == sender_owner
+                || owner_authorized_devices.contains(&device_pubkey);
+            if !has_owner_binding || !record.authorized || record.is_stale {
+                continue;
+            }
 
             if let Some(active_session) = record.active_session.as_ref() {
                 if active_session.matches_sender(envelope.sender) {
@@ -626,12 +694,74 @@ impl SessionManager {
         state: SessionState,
         now: UnixSeconds,
     ) {
+        self.import_claimed_session_state(owner_pubkey, device_pubkey, state, now);
+    }
+
+    /// Import a session whose peer device is authenticated by the ratchet but
+    /// whose claimed owner still requires roster verification.
+    ///
+    /// If the owner/device binding is not verified, the session is retained
+    /// under the device's own identity and the claimed owner remains
+    /// provisional. A later roster containing the device promotes the session
+    /// to the claimed owner.
+    pub fn import_claimed_session_state(
+        &mut self,
+        claimed_owner_pubkey: OwnerPubkey,
+        authenticated_device_pubkey: DevicePubkey,
+        state: SessionState,
+        now: UnixSeconds,
+    ) -> ProcessedInviteResponse {
+        self.store_claimed_session(
+            claimed_owner_pubkey,
+            authenticated_device_pubkey,
+            Session::from_state(state),
+            now,
+        )
+    }
+
+    fn store_claimed_session(
+        &mut self,
+        claimed_owner_pubkey: OwnerPubkey,
+        authenticated_device_pubkey: DevicePubkey,
+        session: Session,
+        now: UnixSeconds,
+    ) -> ProcessedInviteResponse {
+        let device_owner_pubkey =
+            crate::owner_pubkey_from_device_pubkey(authenticated_device_pubkey);
+        let claim_is_verified =
+            self.owner_device_is_authorized(claimed_owner_pubkey, authenticated_device_pubkey);
+        let owner_pubkey = if claim_is_verified {
+            claimed_owner_pubkey
+        } else {
+            device_owner_pubkey
+        };
+        let provisional_claim =
+            (claimed_owner_pubkey != owner_pubkey).then_some(claimed_owner_pubkey);
+        let should_seed_single_device_roster = owner_pubkey == device_owner_pubkey
+            && self
+                .users
+                .get(&owner_pubkey)
+                .and_then(|user| user.roster.as_ref())
+                .is_none();
+
         let user = self.user_record_mut(owner_pubkey);
-        let record = user.device_record_mut(device_pubkey, now);
-        record.authorized = true;
-        record.is_stale = false;
+        if should_seed_single_device_roster {
+            user.roster = Some(DeviceRoster::new(
+                now,
+                vec![AuthorizedDevice::new(authenticated_device_pubkey, now)],
+            ));
+        }
+        let record = user.device_record_mut(authenticated_device_pubkey, now);
+        record.claimed_owner_pubkey = provisional_claim;
         record.invite_response_generated = true;
-        record.upsert_session(Session::from_state(state), now);
+        record.upsert_session(session, now);
+        self.recompute_authorization_for_owner(owner_pubkey);
+
+        ProcessedInviteResponse {
+            owner_pubkey,
+            device_pubkey: authenticated_device_pubkey,
+            claimed_owner_pubkey: provisional_claim,
+        }
     }
 
     fn prepare_device_delivery<R>(
@@ -1028,54 +1158,26 @@ impl SessionManager {
         incoming_roster: DeviceRoster,
         replace_existing: bool,
     ) -> RosterSnapshotDecision {
-        let user = self.user_record_mut(owner_pubkey);
-        let current_roster = user.roster.as_ref();
-        let (decision, next_roster) = if replace_existing {
-            (RosterSnapshotDecision::Advanced, incoming_roster)
-        } else {
-            apply_roster_snapshot(current_roster, &incoming_roster)
+        let (decision, next_roster) = {
+            let user = self.user_record_mut(owner_pubkey);
+            let current_roster = user.roster.as_ref();
+            if replace_existing {
+                (RosterSnapshotDecision::Advanced, incoming_roster)
+            } else {
+                apply_roster_snapshot(current_roster, &incoming_roster)
+            }
         };
 
-        let previous_authorized = current_roster
-            .map(authorized_device_set)
-            .unwrap_or_default();
-        let next_authorized = authorized_device_set(&next_roster);
-
-        user.roster = Some(next_roster.clone());
-
-        for device in next_roster.devices() {
-            let record = user.device_record_mut(device.device_pubkey, device.created_at);
-            record.authorized = true;
-            record.is_stale = false;
-            record.stale_since = None;
-            record.created_at = merge_created_at(record.created_at, device.created_at);
-        }
-
-        for removed in previous_authorized.difference(&next_authorized) {
-            let record = user.device_record_mut(*removed, next_roster.created_at);
-            record.authorized = false;
-            record.is_stale = true;
-            if record.stale_since.is_none() {
-                record.stale_since = Some(next_roster.created_at);
-            }
-        }
-
-        self.reconcile_verified_claimed_devices(owner_pubkey, &next_roster, next_roster.created_at);
+        let next_created_at = next_roster.created_at;
+        self.user_record_mut(owner_pubkey).roster = Some(next_roster);
+        self.recompute_authorization_for_owner(owner_pubkey);
+        self.reconcile_verified_claimed_devices(owner_pubkey, next_created_at);
+        self.recompute_authorization_for_owner(owner_pubkey);
 
         decision
     }
 
-    fn reconcile_verified_claimed_devices(
-        &mut self,
-        owner_pubkey: OwnerPubkey,
-        roster: &DeviceRoster,
-        now: UnixSeconds,
-    ) {
-        let roster_devices = authorized_device_set(roster);
-        if roster_devices.is_empty() {
-            return;
-        }
-
+    fn reconcile_verified_claimed_devices(&mut self, owner_pubkey: OwnerPubkey, now: UnixSeconds) {
         let source_owners: Vec<OwnerPubkey> = self
             .users
             .keys()
@@ -1094,7 +1196,8 @@ impl SessionManager {
                     user.devices
                         .values()
                         .filter(|record| {
-                            if !roster_devices.contains(&record.device_pubkey) {
+                            if !self.owner_device_is_authorized(owner_pubkey, record.device_pubkey)
+                            {
                                 return false;
                             }
                             if record.claimed_owner_pubkey == Some(owner_pubkey) {
@@ -1154,6 +1257,59 @@ impl SessionManager {
         }
     }
 
+    fn owner_device_is_authorized(
+        &self,
+        owner_pubkey: OwnerPubkey,
+        device_pubkey: DevicePubkey,
+    ) -> bool {
+        if crate::owner_pubkey_from_device_pubkey(device_pubkey) == owner_pubkey {
+            return true;
+        }
+        if owner_pubkey == self.local_owner_pubkey {
+            return self
+                .users
+                .get(&owner_pubkey)
+                .and_then(|user| user.roster.as_ref())
+                .and_then(|roster| roster.get_device(&device_pubkey))
+                .is_some();
+        }
+        let Ok(owner) = owner_pubkey.to_nostr() else {
+            return false;
+        };
+        let Ok(device) = device_pubkey.to_nostr() else {
+            return false;
+        };
+        self.verified_peer_app_keys.membership(owner, device) == DeviceMembership::Authorized
+    }
+
+    fn authorized_devices_for_owner(&self, owner_pubkey: OwnerPubkey) -> BTreeSet<DevicePubkey> {
+        self.users
+            .get(&owner_pubkey)
+            .map(|user| {
+                user.roster
+                    .as_ref()
+                    .map(|roster| {
+                        roster
+                            .devices()
+                            .iter()
+                            .filter(|device| {
+                                self.owner_device_is_authorized(owner_pubkey, device.device_pubkey)
+                            })
+                            .map(|device| device.device_pubkey)
+                            .collect()
+                    })
+                    .unwrap_or_default()
+            })
+            .unwrap_or_default()
+    }
+
+    fn recompute_authorization_for_owner(&mut self, owner_pubkey: OwnerPubkey) {
+        let authorized_devices = self.authorized_devices_for_owner(owner_pubkey);
+        if let Some(user) = self.users.get_mut(&owner_pubkey) {
+            user.recompute_authorization(&authorized_devices);
+        }
+    }
+
     fn user_record_mut(&mut self, owner_pubkey: OwnerPubkey) -> &mut UserRecord {
         self.users
             .entry(owner_pubkey)
@@ -1199,6 +1355,50 @@ impl UserRecord {
         self.devices
             .entry(device_pubkey)
             .or_insert_with(|| DeviceRecord::new(device_pubkey, created_at))
+    }
+
+    fn recompute_authorization(&mut self, authorized_devices: &BTreeSet<DevicePubkey>) {
+        let owner_pubkey = self.owner_pubkey;
+        let roster_created_at = self.roster.as_ref().map(|roster| roster.created_at);
+        let roster_devices = self
+            .roster
+            .as_ref()
+            .map(|roster| {
+                roster
+                    .devices()
+                    .iter()
+                    .map(|device| (device.device_pubkey, device.created_at))
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        for record in self.devices.values_mut() {
+            let self_owned =
+                crate::owner_pubkey_from_device_pubkey(record.device_pubkey) == self.owner_pubkey;
+            record.authorized = self_owned || authorized_devices.contains(&record.device_pubkey);
+            if record.authorized {
+                record.is_stale = false;
+                record.stale_since = None;
+            } else if let Some(roster_created_at) = roster_created_at {
+                record.is_stale = true;
+                if record.stale_since.is_none() {
+                    record.stale_since = Some(roster_created_at);
+                }
+            } else {
+                record.is_stale = false;
+                record.stale_since = None;
+            }
+        }
+
+        for (device_pubkey, created_at) in roster_devices {
+            let record = self.device_record_mut(device_pubkey, created_at);
+            record.authorized = authorized_devices.contains(&device_pubkey)
+                || crate::owner_pubkey_from_device_pubkey(device_pubkey) == owner_pubkey;
+            if record.authorized {
+                record.is_stale = false;
+                record.stale_since = None;
+            }
+            record.created_at = merge_created_at(record.created_at, created_at);
+        }
     }
 
     fn authorized_non_stale_devices(&self) -> Vec<DevicePubkey> {
@@ -1450,14 +1650,6 @@ fn apply_roster_snapshot(
         RosterSnapshotDecision::MergedEqualTimestamp,
         current_roster.merge(incoming_roster),
     )
-}
-
-fn authorized_device_set(roster: &DeviceRoster) -> BTreeSet<DevicePubkey> {
-    roster
-        .devices()
-        .iter()
-        .map(|device| device.device_pubkey)
-        .collect()
 }
 
 fn session_priority(session: &Session) -> (u8, u32, u32) {

--- a/rust/crates/nostr-double-ratchet/tests/app_keys_test.rs
+++ b/rust/crates/nostr-double-ratchet/tests/app_keys_test.rs
@@ -2,8 +2,21 @@ use nostr::Keys;
 use nostr_double_ratchet::Result;
 use nostr_double_ratchet::{
     build_app_keys_device_authorization_filter, resolve_app_keys_owner_for_device, AppKeys,
-    DeviceEntry, APP_KEYS_ENCRYPTED_DEVICE_LABELS_FACT,
+    DeviceEntry, DeviceMembership, VerifiedAppKeysIndex, APP_KEYS_ENCRYPTED_DEVICE_LABELS_FACT,
 };
+
+fn signed_app_keys(owner: &Keys, devices: &[nostr::PublicKey], created_at: u64) -> nostr::Event {
+    AppKeys::new(
+        devices
+            .iter()
+            .copied()
+            .map(|device| DeviceEntry::new(device, created_at))
+            .collect(),
+    )
+    .get_event_at(owner.public_key(), created_at)
+    .sign_with_keys(owner)
+    .expect("signed AppKeys")
+}
 
 #[test]
 fn test_app_keys_roundtrip_and_merge() -> Result<()> {
@@ -124,4 +137,96 @@ fn test_app_keys_device_authorization_filter_and_owner_resolution() -> Result<()
     );
 
     Ok(())
+}
+
+#[test]
+fn ordinary_signed_app_keys_authorizes_exact_owner_device_binding() {
+    let owner = Keys::generate();
+    let device = Keys::generate().public_key();
+    let event = signed_app_keys(&owner, &[device], 100);
+
+    let mut index = VerifiedAppKeysIndex::default();
+    assert!(index.ingest(event, 100).unwrap());
+    assert_eq!(
+        index.membership(owner.public_key(), device),
+        DeviceMembership::Authorized
+    );
+}
+
+#[test]
+fn missing_app_keys_does_not_authorize() {
+    let owner = Keys::generate();
+    let device = Keys::generate().public_key();
+    let index = VerifiedAppKeysIndex::default();
+
+    assert_eq!(
+        index.membership(owner.public_key(), device),
+        DeviceMembership::Missing
+    );
+}
+
+#[test]
+fn newer_signed_exclusion_replaces_stale_inclusion() {
+    let owner = Keys::generate();
+    let device = Keys::generate().public_key();
+    let included = signed_app_keys(&owner, &[device], 100);
+    let excluded = signed_app_keys(&owner, &[], 101);
+
+    let mut index = VerifiedAppKeysIndex::default();
+    assert!(index.ingest(included, 101).unwrap());
+    assert!(index.ingest(excluded, 101).unwrap());
+    assert_eq!(
+        index.membership(owner.public_key(), device),
+        DeviceMembership::Excluded
+    );
+}
+
+#[test]
+fn equal_time_membership_conflict_is_ambiguous_in_both_orders() {
+    let owner = Keys::generate();
+    let device = Keys::generate().public_key();
+    let included = signed_app_keys(&owner, &[device], 100);
+    let excluded = signed_app_keys(&owner, &[], 100);
+
+    for events in [
+        vec![included.clone(), excluded.clone()],
+        vec![excluded.clone(), included.clone()],
+    ] {
+        let mut index = VerifiedAppKeysIndex::default();
+        for event in events {
+            index.ingest(event, 100).unwrap();
+        }
+        assert_eq!(
+            index.membership(owner.public_key(), device),
+            DeviceMembership::Ambiguous
+        );
+    }
+}
+
+#[test]
+fn wrong_owner_and_future_app_keys_do_not_authorize() {
+    let owner = Keys::generate();
+    let attacker = Keys::generate();
+    let device = Keys::generate().public_key();
+    let wrong_owner = signed_app_keys(&attacker, &[device], 100);
+    let future = signed_app_keys(&owner, &[device], 401);
+
+    let mut index = VerifiedAppKeysIndex::default();
+    assert!(index.ingest(wrong_owner, 100).is_ok());
+    assert!(index.ingest(future, 100).is_err());
+    assert_eq!(
+        index.membership(owner.public_key(), device),
+        DeviceMembership::Missing
+    );
+}
+
+#[test]
+fn exact_heads_round_trip_for_restart_recovery() {
+    let owner = Keys::generate();
+    let device = Keys::generate().public_key();
+    let event = signed_app_keys(&owner, &[device], 100);
+    let mut index = VerifiedAppKeysIndex::default();
+    index.ingest(event.clone(), 100).unwrap();
+
+    assert_eq!(index.events_for_owner(owner.public_key()), vec![event]);
 }

--- a/rust/crates/nostr-double-ratchet/tests/group_manager_pairwise_adversarial.rs
+++ b/rust/crates/nostr-double-ratchet/tests/group_manager_pairwise_adversarial.rs
@@ -7,7 +7,7 @@ use nostr_double_ratchet::{
     DevicePubkey, DomainError, Error, GroupIncomingEvent, GroupPairwiseCommand, GroupPayloadCodec,
     GroupPayloadEncodeContext, GroupProtocol, GroupSnapshot, OwnerPubkey, Result, UnixSeconds,
 };
-use support::{context, manager_device, roster_for, session_manager};
+use support::{context, manager_device, observe_signed_peer_app_keys, session_manager};
 
 fn create_remote_owned_group(
     local_owner: OwnerPubkey,
@@ -346,8 +346,8 @@ fn removed_member_cannot_send_after_processing_removal() -> Result<()> {
     let mut alice_groups = GroupManager::new(alice.owner_pubkey);
     let mut bob_groups = GroupManager::new(bob.owner_pubkey);
 
-    bob_manager.observe_peer_roster(alice.owner_pubkey, roster_for(&[&alice], 49));
-    alice_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 50));
+    observe_signed_peer_app_keys(&mut bob_manager, &alice, &[&alice], 49)?;
+    observe_signed_peer_app_keys(&mut alice_manager, &bob, &[&bob], 50)?;
     alice_manager.observe_device_invite(
         bob.owner_pubkey,
         support::manager_public_device_invite(&mut bob_manager, &bob, 8, 1_900_001_040)?,

--- a/rust/crates/nostr-double-ratchet/tests/group_manager_pairwise_basic.rs
+++ b/rust/crates/nostr-double-ratchet/tests/group_manager_pairwise_basic.rs
@@ -6,7 +6,7 @@ use nostr_double_ratchet::{
 };
 use support::{
     context, manager_device, manager_observe_invite_response, manager_public_device_invite,
-    manager_receive_delivery, roster_for, session_manager, snapshot,
+    manager_receive_delivery, observe_signed_peer_app_keys, roster_for, session_manager, snapshot,
 };
 
 fn observe_matching_invite_responses(
@@ -140,8 +140,8 @@ fn retry_create_group_reuses_existing_group_id_without_remutating_state() -> Res
     assert_eq!(created.prepared.remote.deliveries.len(), 0);
     assert_eq!(alice_groups.groups().len(), 1);
 
-    bob_manager.observe_peer_roster(alice.owner_pubkey, roster_for(&[&alice], 60));
-    alice_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 61));
+    observe_signed_peer_app_keys(&mut bob_manager, &alice, &[&alice], 60)?;
+    observe_signed_peer_app_keys(&mut alice_manager, &bob, &[&bob], 61)?;
     alice_manager.observe_device_invite(
         bob.owner_pubkey,
         manager_public_device_invite(&mut bob_manager, &bob, 18, 1_900_001_101)?,
@@ -200,8 +200,8 @@ fn add_members_bootstraps_new_member_with_current_group_state() -> Result<()> {
         vec![],
     )?;
 
-    bob_manager.observe_peer_roster(alice.owner_pubkey, roster_for(&[&alice], 10));
-    alice_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 11));
+    observe_signed_peer_app_keys(&mut bob_manager, &alice, &[&alice], 10)?;
+    observe_signed_peer_app_keys(&mut alice_manager, &bob, &[&bob], 11)?;
     alice_manager.observe_device_invite(
         bob.owner_pubkey,
         manager_public_device_invite(&mut bob_manager, &bob, 3, 1_900_000_101)?,
@@ -286,8 +286,8 @@ fn retry_add_members_reuses_applied_group_state() -> Result<()> {
         }]
     );
 
-    bob_manager.observe_peer_roster(alice.owner_pubkey, roster_for(&[&alice], 62));
-    alice_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 63));
+    observe_signed_peer_app_keys(&mut bob_manager, &alice, &[&alice], 62)?;
+    observe_signed_peer_app_keys(&mut alice_manager, &bob, &[&bob], 63)?;
     alice_manager.observe_device_invite(
         bob.owner_pubkey,
         manager_public_device_invite(&mut bob_manager, &bob, 23, 1_900_001_201)?,
@@ -342,12 +342,12 @@ fn create_and_send_message_fan_out_to_remote_member_and_local_sibling() -> Resul
 
     alice1_manager.apply_local_roster(roster_for(&[&alice1, &alice2], 20));
     alice2_manager.apply_local_roster(roster_for(&[&alice1, &alice2], 20));
-    bob_manager.observe_peer_roster(alice1.owner_pubkey, roster_for(&[&alice1], 20));
+    observe_signed_peer_app_keys(&mut bob_manager, &alice1, &[&alice1], 20)?;
     alice1_manager.observe_device_invite(
         alice1.owner_pubkey,
         manager_public_device_invite(&mut alice2_manager, &alice2, 20, 1_900_000_200)?,
     )?;
-    alice1_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 21));
+    observe_signed_peer_app_keys(&mut alice1_manager, &bob, &[&bob], 21)?;
     alice1_manager.observe_device_invite(
         bob.owner_pubkey,
         manager_public_device_invite(&mut bob_manager, &bob, 21, 1_900_000_201)?,
@@ -477,7 +477,7 @@ fn send_message_bootstraps_existing_group_to_new_local_sibling() -> Result<()> {
     let _bob_groups = GroupManager::new(bob.owner_pubkey);
 
     alice1_manager.apply_local_roster(roster_for(&[&alice1], 70));
-    alice1_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 71));
+    observe_signed_peer_app_keys(&mut alice1_manager, &bob, &[&bob], 71)?;
     alice1_manager.observe_device_invite(
         bob.owner_pubkey,
         manager_public_device_invite(&mut bob_manager, &bob, 72, 1_900_001_300)?,
@@ -554,7 +554,7 @@ fn send_message_merges_relay_gaps_from_members_without_transport_state() -> Resu
     )?;
     assert_eq!(created.prepared.remote.relay_gaps.len(), 2);
 
-    manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 31));
+    observe_signed_peer_app_keys(&mut manager, &bob, &[&bob], 31)?;
     let mut send_ctx = context(16, 1_900_000_301);
     let prepared = groups.send_message(
         &mut manager,

--- a/rust/crates/nostr-double-ratchet/tests/group_manager_sender_key_basic.rs
+++ b/rust/crates/nostr-double-ratchet/tests/group_manager_sender_key_basic.rs
@@ -10,7 +10,7 @@ use nostr_double_ratchet::{
 };
 use support::{
     context, manager_device, manager_observe_invite_response, manager_public_device_invite,
-    manager_receive_delivery, roster_for, session_manager, snapshot,
+    manager_receive_delivery, observe_signed_peer_app_keys, roster_for, session_manager, snapshot,
 };
 
 struct SenderKeyFixture {
@@ -169,8 +169,8 @@ fn established_sender_key_fixture(owner_fill: u8, base_secs: u64) -> Result<Send
     let mut alice_groups = GroupManager::new(alice.owner_pubkey);
     let mut bob_groups = GroupManager::new(bob.owner_pubkey);
 
-    bob_manager.observe_peer_roster(alice.owner_pubkey, roster_for(&[&alice], base_secs));
-    alice_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], base_secs + 1));
+    observe_signed_peer_app_keys(&mut bob_manager, &alice, &[&alice], base_secs)?;
+    observe_signed_peer_app_keys(&mut alice_manager, &bob, &[&bob], base_secs + 1)?;
     alice_manager.observe_device_invite(
         bob.owner_pubkey,
         manager_public_device_invite(&mut bob_manager, &bob, base_secs + 2, base_secs + 2)?,
@@ -224,12 +224,12 @@ fn late_member_repair_fixture(
     let mut bob_groups = GroupManager::new(bob.owner_pubkey);
     let mut carol_groups = GroupManager::new(carol.owner_pubkey);
 
-    bob_manager.observe_peer_roster(alice.owner_pubkey, roster_for(&[&alice], base_secs));
-    carol_manager.observe_peer_roster(alice.owner_pubkey, roster_for(&[&alice], base_secs + 1));
-    carol_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], base_secs + 2));
-    alice_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], base_secs + 3));
-    alice_manager.observe_peer_roster(carol.owner_pubkey, roster_for(&[&carol], base_secs + 4));
-    bob_manager.observe_peer_roster(carol.owner_pubkey, roster_for(&[&carol], base_secs + 5));
+    observe_signed_peer_app_keys(&mut bob_manager, &alice, &[&alice], base_secs)?;
+    observe_signed_peer_app_keys(&mut carol_manager, &alice, &[&alice], base_secs + 1)?;
+    observe_signed_peer_app_keys(&mut carol_manager, &bob, &[&bob], base_secs + 2)?;
+    observe_signed_peer_app_keys(&mut alice_manager, &bob, &[&bob], base_secs + 3)?;
+    observe_signed_peer_app_keys(&mut alice_manager, &carol, &[&carol], base_secs + 4)?;
+    observe_signed_peer_app_keys(&mut bob_manager, &carol, &[&carol], base_secs + 5)?;
     alice_manager.observe_device_invite(
         bob.owner_pubkey,
         manager_public_device_invite(&mut bob_manager, &bob, base_secs + 6, base_secs + 6)?,
@@ -384,8 +384,8 @@ fn sender_key_group_create_distributes_key_and_shared_message_decrypts() -> Resu
     let mut alice_groups = GroupManager::new(alice.owner_pubkey);
     let mut bob_groups = GroupManager::new(bob.owner_pubkey);
 
-    bob_manager.observe_peer_roster(alice.owner_pubkey, roster_for(&[&alice], 10));
-    alice_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 11));
+    observe_signed_peer_app_keys(&mut bob_manager, &alice, &[&alice], 10)?;
+    observe_signed_peer_app_keys(&mut alice_manager, &bob, &[&bob], 11)?;
     alice_manager.observe_device_invite(
         bob.owner_pubkey,
         manager_public_device_invite(&mut bob_manager, &bob, 12, 1_900_010_000)?,
@@ -469,7 +469,7 @@ fn sender_key_group_create_syncs_to_local_sibling() -> Result<()> {
         alice1.owner_pubkey,
         manager_public_device_invite(&mut alice2_manager, &alice2, 41, 1_900_030_100)?,
     )?;
-    alice1_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 42));
+    observe_signed_peer_app_keys(&mut alice1_manager, &bob, &[&bob], 42)?;
     alice1_manager.observe_device_invite(
         bob.owner_pubkey,
         manager_public_device_invite(&mut bob_manager, &bob, 43, 1_900_030_101)?,
@@ -552,8 +552,8 @@ fn sender_key_local_sibling_can_repair_missed_rotated_distribution() -> Result<(
         alice1.owner_pubkey,
         manager_public_device_invite(&mut alice2_manager, &alice2, 1_900_077_001, 1_900_077_001)?,
     )?;
-    alice1_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 1_900_077_002));
-    alice1_manager.observe_peer_roster(carol.owner_pubkey, roster_for(&[&carol], 1_900_077_003));
+    observe_signed_peer_app_keys(&mut alice1_manager, &bob, &[&bob], 1_900_077_002)?;
+    observe_signed_peer_app_keys(&mut alice1_manager, &carol, &[&carol], 1_900_077_003)?;
     alice1_manager.observe_device_invite(
         bob.owner_pubkey,
         manager_public_device_invite(&mut bob_manager, &bob, 1_900_077_004, 1_900_077_004)?,
@@ -755,8 +755,8 @@ fn sender_key_outer_message_waits_for_distribution() -> Result<()> {
     let mut alice_groups = GroupManager::new(alice.owner_pubkey);
     let mut bob_groups = GroupManager::new(bob.owner_pubkey);
 
-    bob_manager.observe_peer_roster(alice.owner_pubkey, roster_for(&[&alice], 20));
-    alice_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 21));
+    observe_signed_peer_app_keys(&mut bob_manager, &alice, &[&alice], 20)?;
+    observe_signed_peer_app_keys(&mut alice_manager, &bob, &[&bob], 21)?;
     alice_manager.observe_device_invite(
         bob.owner_pubkey,
         manager_public_device_invite(&mut bob_manager, &bob, 22, 1_900_020_000)?,
@@ -824,8 +824,8 @@ fn sender_key_repair_request_restores_original_distribution_after_sender_chain_a
     let mut alice_groups = GroupManager::new(alice.owner_pubkey);
     let mut bob_groups = GroupManager::new(bob.owner_pubkey);
 
-    bob_manager.observe_peer_roster(alice.owner_pubkey, roster_for(&[&alice], 1_900_070_000));
-    alice_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 1_900_070_001));
+    observe_signed_peer_app_keys(&mut bob_manager, &alice, &[&alice], 1_900_070_000)?;
+    observe_signed_peer_app_keys(&mut alice_manager, &bob, &[&bob], 1_900_070_001)?;
     alice_manager.observe_device_invite(
         bob.owner_pubkey,
         manager_public_device_invite(&mut bob_manager, &bob, 1_900_070_002, 1_900_070_002)?,
@@ -1134,8 +1134,8 @@ fn sender_key_distribution_requires_authenticated_device_provenance() -> Result<
     let mut alice_groups = GroupManager::new(alice.owner_pubkey);
     let mut bob_groups = GroupManager::new(bob.owner_pubkey);
 
-    bob_manager.observe_peer_roster(alice.owner_pubkey, roster_for(&[&alice], 30));
-    alice_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 31));
+    observe_signed_peer_app_keys(&mut bob_manager, &alice, &[&alice], 30)?;
+    observe_signed_peer_app_keys(&mut alice_manager, &bob, &[&bob], 31)?;
     alice_manager.observe_device_invite(
         bob.owner_pubkey,
         manager_public_device_invite(&mut bob_manager, &bob, 32, 1_900_030_000)?,
@@ -1453,13 +1453,13 @@ fn sender_key_added_member_receives_distribution_at_current_iteration() -> Resul
     let mut carol_manager = session_manager(&carol);
     let mut carol_groups = GroupManager::new(carol.owner_pubkey);
 
-    carol_manager.observe_peer_roster(
-        fixture.alice.owner_pubkey,
-        roster_for(&[&fixture.alice], 1_900_045_010),
-    );
-    fixture
-        .alice_manager
-        .observe_peer_roster(carol.owner_pubkey, roster_for(&[&carol], 1_900_045_011));
+    observe_signed_peer_app_keys(
+        &mut carol_manager,
+        &fixture.alice,
+        &[&fixture.alice],
+        1_900_045_010,
+    )?;
+    observe_signed_peer_app_keys(&mut fixture.alice_manager, &carol, &[&carol], 1_900_045_011)?;
     fixture.alice_manager.observe_device_invite(
         carol.owner_pubkey,
         manager_public_device_invite(&mut carol_manager, &carol, 1_900_045_012, 1_900_045_012)?,
@@ -1538,12 +1538,12 @@ fn sender_key_existing_member_distributes_current_key_to_late_member_on_next_sen
     let mut bob_groups = GroupManager::new(bob.owner_pubkey);
     let mut carol_groups = GroupManager::new(carol.owner_pubkey);
 
-    bob_manager.observe_peer_roster(alice.owner_pubkey, roster_for(&[&alice], 1_900_045_100));
-    carol_manager.observe_peer_roster(alice.owner_pubkey, roster_for(&[&alice], 1_900_045_101));
-    carol_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 1_900_045_102));
-    alice_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 1_900_045_103));
-    alice_manager.observe_peer_roster(carol.owner_pubkey, roster_for(&[&carol], 1_900_045_104));
-    bob_manager.observe_peer_roster(carol.owner_pubkey, roster_for(&[&carol], 1_900_045_105));
+    observe_signed_peer_app_keys(&mut bob_manager, &alice, &[&alice], 1_900_045_100)?;
+    observe_signed_peer_app_keys(&mut carol_manager, &alice, &[&alice], 1_900_045_101)?;
+    observe_signed_peer_app_keys(&mut carol_manager, &bob, &[&bob], 1_900_045_102)?;
+    observe_signed_peer_app_keys(&mut alice_manager, &bob, &[&bob], 1_900_045_103)?;
+    observe_signed_peer_app_keys(&mut alice_manager, &carol, &[&carol], 1_900_045_104)?;
+    observe_signed_peer_app_keys(&mut bob_manager, &carol, &[&carol], 1_900_045_105)?;
     alice_manager.observe_device_invite(
         bob.owner_pubkey,
         manager_public_device_invite(&mut bob_manager, &bob, 1_900_045_106, 1_900_045_106)?,
@@ -1693,10 +1693,10 @@ fn sender_key_removed_member_does_not_receive_rotated_future_key() -> Result<()>
     let mut bob_groups = GroupManager::new(bob.owner_pubkey);
     let mut carol_groups = GroupManager::new(carol.owner_pubkey);
 
-    bob_manager.observe_peer_roster(alice.owner_pubkey, roster_for(&[&alice], 1_900_046_000));
-    carol_manager.observe_peer_roster(alice.owner_pubkey, roster_for(&[&alice], 1_900_046_001));
-    alice_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 1_900_046_002));
-    alice_manager.observe_peer_roster(carol.owner_pubkey, roster_for(&[&carol], 1_900_046_003));
+    observe_signed_peer_app_keys(&mut bob_manager, &alice, &[&alice], 1_900_046_000)?;
+    observe_signed_peer_app_keys(&mut carol_manager, &alice, &[&alice], 1_900_046_001)?;
+    observe_signed_peer_app_keys(&mut alice_manager, &bob, &[&bob], 1_900_046_002)?;
+    observe_signed_peer_app_keys(&mut alice_manager, &carol, &[&carol], 1_900_046_003)?;
     alice_manager.observe_device_invite(
         bob.owner_pubkey,
         manager_public_device_invite(&mut bob_manager, &bob, 1_900_046_004, 1_900_046_004)?,
@@ -1820,11 +1820,11 @@ fn sender_key_existing_member_rotates_after_another_admin_removes_prior_recipien
     let mut bob_groups = GroupManager::new(bob.owner_pubkey);
     let mut carol_groups = GroupManager::new(carol.owner_pubkey);
 
-    bob_manager.observe_peer_roster(alice.owner_pubkey, roster_for(&[&alice], 1_900_046_100));
-    carol_manager.observe_peer_roster(alice.owner_pubkey, roster_for(&[&alice], 1_900_046_101));
-    alice_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 1_900_046_102));
-    alice_manager.observe_peer_roster(carol.owner_pubkey, roster_for(&[&carol], 1_900_046_103));
-    bob_manager.observe_peer_roster(carol.owner_pubkey, roster_for(&[&carol], 1_900_046_104));
+    observe_signed_peer_app_keys(&mut bob_manager, &alice, &[&alice], 1_900_046_100)?;
+    observe_signed_peer_app_keys(&mut carol_manager, &alice, &[&alice], 1_900_046_101)?;
+    observe_signed_peer_app_keys(&mut alice_manager, &bob, &[&bob], 1_900_046_102)?;
+    observe_signed_peer_app_keys(&mut alice_manager, &carol, &[&carol], 1_900_046_103)?;
+    observe_signed_peer_app_keys(&mut bob_manager, &carol, &[&carol], 1_900_046_104)?;
     alice_manager.observe_device_invite(
         bob.owner_pubkey,
         manager_public_device_invite(&mut bob_manager, &bob, 1_900_046_105, 1_900_046_105)?,

--- a/rust/crates/nostr-double-ratchet/tests/roster_editor_basic.rs
+++ b/rust/crates/nostr-double-ratchet/tests/roster_editor_basic.rs
@@ -3,7 +3,7 @@ mod support;
 use nostr_double_ratchet::{DevicePubkey, Result, RosterEditor, UnixSeconds};
 use support::{
     context, manager_device, manager_device_snapshot, manager_public_device_invite,
-    manager_user_snapshot, prepared_targets, roster_for, session_manager,
+    manager_user_snapshot, observe_signed_peer_app_keys, prepared_targets, session_manager,
 };
 
 #[test]
@@ -79,7 +79,7 @@ fn roster_editor_can_drive_local_sibling_fanout_without_session_manager_crud() -
         manager_public_device_invite(&mut alice2_manager, &alice2, 42, 1_850_000_042)?,
     )?;
 
-    alice_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 43));
+    observe_signed_peer_app_keys(&mut alice_manager, &bob, &[&bob], 43)?;
     alice_manager.observe_device_invite(
         bob.owner_pubkey,
         manager_public_device_invite(&mut bob_manager, &bob, 43, 1_850_000_043)?,

--- a/rust/crates/nostr-double-ratchet/tests/session_manager_sesame_adversarial.rs
+++ b/rust/crates/nostr-double-ratchet/tests/session_manager_sesame_adversarial.rs
@@ -690,6 +690,33 @@ fn equal_time_signed_conflict_suspends_owner_attribution_across_restore() -> Res
 }
 
 #[test]
+fn equivalent_equal_time_signed_app_keys_is_idempotent_across_restore() -> Result<()> {
+    let local = manager_device(61, 161);
+    let peer = manager_device(62, 162);
+    let peer_linked = manager_device(63, 163);
+    let mut manager = session_manager(&local);
+    let first = signed_app_keys_for(&peer, &[&peer, &peer_linked], 141);
+    let equivalent = signed_app_keys_for(&peer, &[&peer, &peer_linked], 141);
+
+    assert_ne!(first.id, equivalent.id);
+    assert!(manager.observe_peer_app_keys_event(first, UnixSeconds(141))?);
+    assert!(!manager.observe_peer_app_keys_event(equivalent, UnixSeconds(141))?);
+
+    let snapshot = manager.snapshot();
+    assert_eq!(snapshot.verified_peer_app_keys_events.len(), 1);
+    let restored = restore_manager(&snapshot, local.secret_key)?;
+    assert_eq!(restored.snapshot().verified_peer_app_keys_events.len(), 1);
+    assert!(
+        manager_device_snapshot(
+            manager_user_snapshot(&restored.snapshot(), peer.owner_pubkey),
+            peer_linked.device_pubkey,
+        )
+        .authorized
+    );
+    Ok(())
+}
+
+#[test]
 fn tampered_delivery_does_not_corrupt_receiver_state() -> Result<()> {
     let alice = manager_device(15, 151);
     let bob = manager_device(16, 161);

--- a/rust/crates/nostr-double-ratchet/tests/session_manager_sesame_adversarial.rs
+++ b/rust/crates/nostr-double-ratchet/tests/session_manager_sesame_adversarial.rs
@@ -1,10 +1,13 @@
 mod support;
 
-use nostr_double_ratchet::{DomainError, Error, RelayGap, Result, UnixSeconds};
+use nostr_double_ratchet::{
+    DomainError, Error, RelayGap, Result, RosterSnapshotDecision, UnixSeconds, UserRecordSnapshot,
+};
 use support::{
-    context, manager_device, manager_device_snapshot, manager_observe_invite_response,
-    manager_public_device_invite, manager_receive_delivery, manager_user_snapshot, mutate_text,
-    provisional_owner_pubkey, restore_manager, roster_for, session_manager, snapshot,
+    context, direct_session_pair, manager_device, manager_device_snapshot,
+    manager_observe_invite_response, manager_public_device_invite, manager_receive_delivery,
+    manager_user_snapshot, mutate_text, provisional_owner_pubkey, restore_manager, roster_for,
+    send_text, session_manager, signed_app_keys_for, snapshot,
 };
 
 #[test]
@@ -31,7 +34,8 @@ fn missing_device_invite_surfaces_gap_not_hidden_failure() -> Result<()> {
     let bob = manager_device(24, 241);
     let mut alice_manager = session_manager(&alice);
 
-    alice_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 10));
+    alice_manager
+        .observe_peer_app_keys_event(signed_app_keys_for(&bob, &[&bob], 10), UnixSeconds(10))?;
 
     let mut send_ctx = context(2, 1_810_000_010);
     let prepared = alice_manager.prepare_send(&mut send_ctx, bob.owner_pubkey, b"gap".to_vec())?;
@@ -105,7 +109,8 @@ fn invite_response_replay_is_rejected_and_state_unchanged() -> Result<()> {
     let mut alice_manager = session_manager(&alice);
     let mut bob_manager = session_manager(&bob);
 
-    alice_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 20));
+    alice_manager
+        .observe_peer_app_keys_event(signed_app_keys_for(&bob, &[&bob], 20), UnixSeconds(20))?;
     alice_manager.observe_device_invite(
         bob.owner_pubkey,
         manager_public_device_invite(&mut bob_manager, &bob, 20, 1_810_000_100)?,
@@ -145,8 +150,10 @@ fn message_replay_on_active_session_is_rejected_without_corruption() -> Result<(
     let mut alice_manager = session_manager(&alice);
     let mut bob_manager = session_manager(&bob);
 
-    alice_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 30));
-    bob_manager.observe_peer_roster(alice.owner_pubkey, roster_for(&[&alice], 30));
+    alice_manager
+        .observe_peer_app_keys_event(signed_app_keys_for(&bob, &[&bob], 30), UnixSeconds(30))?;
+    bob_manager
+        .observe_peer_app_keys_event(signed_app_keys_for(&alice, &[&alice], 30), UnixSeconds(30))?;
     alice_manager.observe_device_invite(
         bob.owner_pubkey,
         manager_public_device_invite(&mut bob_manager, &bob, 30, 1_810_000_200)?,
@@ -218,13 +225,10 @@ fn stale_roster_replay_does_not_resurrect_removed_device() -> Result<()> {
     let bob = manager_device(36, 111);
     let mut manager = session_manager(&alice);
 
-    manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 50));
-    manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[], 51));
-    let decision = manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 50));
-    assert_eq!(
-        decision,
-        nostr_double_ratchet::RosterSnapshotDecision::Stale
-    );
+    manager.observe_peer_app_keys_event(signed_app_keys_for(&bob, &[&bob], 50), UnixSeconds(50))?;
+    manager.observe_peer_app_keys_event(signed_app_keys_for(&bob, &[], 51), UnixSeconds(51))?;
+    assert!(!manager
+        .observe_peer_app_keys_event(signed_app_keys_for(&bob, &[&bob], 50), UnixSeconds(51),)?);
 
     let snapshot = manager.snapshot();
     let bob_record = manager_device_snapshot(
@@ -243,10 +247,10 @@ fn pruned_stale_device_is_not_sendable_after_late_old_invite_observation() -> Re
     let mut manager = session_manager(&alice);
     let mut bob_manager = session_manager(&bob);
 
-    manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 60));
+    manager.observe_peer_app_keys_event(signed_app_keys_for(&bob, &[&bob], 60), UnixSeconds(60))?;
     let old_invite = manager_public_device_invite(&mut bob_manager, &bob, 60, 1_810_000_400)?;
     manager.observe_device_invite(bob.owner_pubkey, old_invite.clone())?;
-    manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[], 61));
+    manager.observe_peer_app_keys_event(signed_app_keys_for(&bob, &[], 61), UnixSeconds(61))?;
     manager.prune_stale(UnixSeconds(61 + 8 * 24 * 60 * 60));
 
     manager.observe_device_invite(bob.owner_pubkey, old_invite)?;
@@ -265,8 +269,10 @@ fn late_message_after_pruned_stale_record_is_ignored() -> Result<()> {
     let mut alice_manager = session_manager(&alice);
     let mut bob_manager = session_manager(&bob);
 
-    alice_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 70));
-    bob_manager.observe_peer_roster(alice.owner_pubkey, roster_for(&[&alice], 70));
+    alice_manager
+        .observe_peer_app_keys_event(signed_app_keys_for(&bob, &[&bob], 70), UnixSeconds(70))?;
+    bob_manager
+        .observe_peer_app_keys_event(signed_app_keys_for(&alice, &[&alice], 70), UnixSeconds(70))?;
     alice_manager.observe_device_invite(
         bob.owner_pubkey,
         manager_public_device_invite(&mut bob_manager, &bob, 70, 1_810_000_500)?,
@@ -297,7 +303,8 @@ fn late_message_after_pruned_stale_record_is_ignored() -> Result<()> {
     let delayed =
         bob_manager.prepare_send(&mut bob_send_ctx, alice.owner_pubkey, b"late".to_vec())?;
 
-    alice_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[], 72));
+    alice_manager
+        .observe_peer_app_keys_event(signed_app_keys_for(&bob, &[], 72), UnixSeconds(72))?;
     alice_manager.prune_stale(UnixSeconds(72 + 8 * 24 * 60 * 60));
 
     let mut receive_ctx = context(17, 1_810_000_506);
@@ -319,7 +326,8 @@ fn unverified_owner_claim_is_parked_under_device_owner_until_roster_arrives() ->
     let mut alice_manager = session_manager(&alice);
     let mut bob_manager = session_manager(&bob);
 
-    bob_manager.observe_peer_roster(alice.owner_pubkey, roster_for(&[&alice], 90));
+    bob_manager
+        .observe_peer_app_keys_event(signed_app_keys_for(&alice, &[&alice], 90), UnixSeconds(90))?;
     bob_manager.observe_device_invite(
         alice.owner_pubkey,
         manager_public_device_invite(&mut alice_manager, &alice, 90, 1_810_000_900)?,
@@ -351,6 +359,337 @@ fn unverified_owner_claim_is_parked_under_device_owner_until_roster_arrives() ->
 }
 
 #[test]
+fn claimed_session_import_cannot_impersonate_owner_before_roster_verification() -> Result<()> {
+    let local = manager_device(43, 143);
+    let claimed_owner = manager_device(44, 144);
+    let attacker = manager_device(45, 145);
+    let (sender, _, mut sender_session, receiver_session) =
+        direct_session_pair(145, 146, 1_810_001_000)?;
+    assert_eq!(sender.device_pubkey, attacker.device_pubkey);
+
+    let mut manager = session_manager(&local);
+    let imported = manager.import_claimed_session_state(
+        claimed_owner.owner_pubkey,
+        attacker.device_pubkey,
+        receiver_session.state,
+        UnixSeconds(1_810_001_001),
+    );
+    let provisional_owner = provisional_owner_pubkey(attacker.device_pubkey);
+    assert_eq!(imported.owner_pubkey, provisional_owner);
+    assert_eq!(
+        imported.claimed_owner_pubkey,
+        Some(claimed_owner.owner_pubkey)
+    );
+
+    let parked_snapshot = manager.snapshot();
+    assert!(parked_snapshot
+        .users
+        .iter()
+        .all(|user| user.owner_pubkey != claimed_owner.owner_pubkey));
+    let parked_record = manager_device_snapshot(
+        manager_user_snapshot(&parked_snapshot, provisional_owner),
+        attacker.device_pubkey,
+    );
+    assert!(parked_record.authorized);
+    assert_eq!(
+        parked_record.claimed_owner_pubkey,
+        Some(claimed_owner.owner_pubkey)
+    );
+
+    let mut first_send_ctx = context(20, 1_810_001_002);
+    let first = send_text(&mut sender_session, &mut first_send_ctx, "before-proof")?;
+    let mut claimed_receive_ctx = context(21, 1_810_001_003);
+    assert!(manager
+        .receive(
+            &mut claimed_receive_ctx,
+            claimed_owner.owner_pubkey,
+            &first.incoming,
+        )?
+        .is_none());
+
+    let mut provisional_receive_ctx = context(22, 1_810_001_004);
+    let provisional_received = manager
+        .receive(
+            &mut provisional_receive_ctx,
+            provisional_owner,
+            &first.incoming,
+        )?
+        .expect("device-owned session remains usable without owner attribution");
+    assert_eq!(provisional_received.payload, b"before-proof");
+
+    manager.observe_peer_roster(claimed_owner.owner_pubkey, roster_for(&[&attacker], 100));
+    let still_parked = manager.snapshot();
+    let still_parked_record = manager_device_snapshot(
+        manager_user_snapshot(&still_parked, provisional_owner),
+        attacker.device_pubkey,
+    );
+    assert_eq!(
+        still_parked_record.claimed_owner_pubkey,
+        Some(claimed_owner.owner_pubkey)
+    );
+    assert!(still_parked_record.active_session.is_some());
+
+    manager.observe_peer_app_keys_event(
+        signed_app_keys_for(&claimed_owner, &[&attacker], 100),
+        UnixSeconds(100),
+    )?;
+    let promoted_snapshot = manager.snapshot();
+    assert!(promoted_snapshot
+        .users
+        .iter()
+        .all(|user| user.owner_pubkey != provisional_owner));
+    let promoted_record = manager_device_snapshot(
+        manager_user_snapshot(&promoted_snapshot, claimed_owner.owner_pubkey),
+        attacker.device_pubkey,
+    );
+    assert!(promoted_record.authorized);
+    assert_eq!(promoted_record.claimed_owner_pubkey, None);
+
+    let mut second_send_ctx = context(23, 1_810_001_005);
+    let second = send_text(&mut sender_session, &mut second_send_ctx, "after-proof")?;
+    let mut verified_receive_ctx = context(24, 1_810_001_006);
+    let verified_received = manager
+        .receive(
+            &mut verified_receive_ctx,
+            claimed_owner.owner_pubkey,
+            &second.incoming,
+        )?
+        .expect("verified roster should promote the parked session");
+    assert_eq!(verified_received.payload, b"after-proof");
+    Ok(())
+}
+
+#[test]
+fn generic_session_import_uses_claimed_owner_verification() -> Result<()> {
+    let local = manager_device(46, 146);
+    let claimed_owner = manager_device(47, 147);
+    let attacker = manager_device(48, 148);
+    let (_, _, _, receiver_session) = direct_session_pair(148, 149, 1_810_001_100)?;
+    let mut manager = session_manager(&local);
+
+    manager.import_session_state(
+        claimed_owner.owner_pubkey,
+        attacker.device_pubkey,
+        receiver_session.state,
+        UnixSeconds(1_810_001_101),
+    );
+
+    let snapshot = manager.snapshot();
+    assert!(snapshot
+        .users
+        .iter()
+        .all(|user| user.owner_pubkey != claimed_owner.owner_pubkey));
+    let parked = manager_device_snapshot(
+        manager_user_snapshot(&snapshot, provisional_owner_pubkey(attacker.device_pubkey)),
+        attacker.device_pubkey,
+    );
+    assert_eq!(
+        parked.claimed_owner_pubkey,
+        Some(claimed_owner.owner_pubkey)
+    );
+    Ok(())
+}
+
+#[test]
+fn peer_roster_api_cannot_modify_local_owner_authority() {
+    let local = manager_device(61, 161);
+    let attacker = manager_device(62, 162);
+    let mut manager = session_manager(&local);
+
+    assert_eq!(
+        manager.observe_peer_roster(local.owner_pubkey, roster_for(&[&attacker], 150)),
+        RosterSnapshotDecision::Stale
+    );
+    assert!(manager
+        .snapshot()
+        .users
+        .iter()
+        .all(|user| user.owner_pubkey != local.owner_pubkey));
+}
+
+#[test]
+fn restore_ignores_cached_authorization_without_owner_binding() -> Result<()> {
+    let local = manager_device(49, 149);
+    let claimed_owner = manager_device(50, 150);
+    let attacker = manager_device(51, 151);
+    let (_, _, mut sender_session, receiver_session) =
+        direct_session_pair(151, 152, 1_810_001_200)?;
+    let mut manager = session_manager(&local);
+
+    manager.observe_peer_roster(claimed_owner.owner_pubkey, roster_for(&[&attacker], 110));
+    manager.import_session_state(
+        claimed_owner.owner_pubkey,
+        attacker.device_pubkey,
+        receiver_session.state,
+        UnixSeconds(1_810_001_201),
+    );
+
+    let mut forged_snapshot = manager.snapshot();
+    let forged_user = forged_snapshot
+        .users
+        .iter_mut()
+        .find(|user| user.owner_pubkey == claimed_owner.owner_pubkey)
+        .expect("claimed owner record");
+    forged_user.roster = None;
+    let forged_record = forged_user
+        .devices
+        .iter_mut()
+        .find(|record| record.device_pubkey == attacker.device_pubkey)
+        .expect("attacker device record");
+    forged_record.authorized = true;
+    forged_record.is_stale = false;
+
+    let mut restored = restore_manager(&forged_snapshot, local.secret_key)?;
+    let restored_snapshot = restored.snapshot();
+    let restored_record = manager_device_snapshot(
+        manager_user_snapshot(&restored_snapshot, claimed_owner.owner_pubkey),
+        attacker.device_pubkey,
+    );
+    assert!(!restored_record.authorized);
+
+    let mut send_ctx = context(25, 1_810_001_202);
+    let message = send_text(&mut sender_session, &mut send_ctx, "cached-flag")?;
+    let mut receive_ctx = context(26, 1_810_001_203);
+    assert!(restored
+        .receive(
+            &mut receive_ctx,
+            claimed_owner.owner_pubkey,
+            &message.incoming,
+        )?
+        .is_none());
+    Ok(())
+}
+
+#[test]
+fn restore_does_not_reconcile_parked_claim_from_unproven_roster() -> Result<()> {
+    let local = manager_device(52, 152);
+    let claimed_owner = manager_device(53, 153);
+    let attacker = manager_device(54, 154);
+    let (_, _, _, receiver_session) = direct_session_pair(154, 155, 1_810_001_300)?;
+    let mut manager = session_manager(&local);
+    manager.import_claimed_session_state(
+        claimed_owner.owner_pubkey,
+        attacker.device_pubkey,
+        receiver_session.state,
+        UnixSeconds(1_810_001_301),
+    );
+
+    let mut snapshot = manager.snapshot();
+    snapshot.users.push(UserRecordSnapshot {
+        owner_pubkey: claimed_owner.owner_pubkey,
+        roster: Some(roster_for(&[&attacker], 120)),
+        devices: Vec::new(),
+    });
+
+    let restored = restore_manager(&snapshot, local.secret_key)?;
+    let restored_snapshot = restored.snapshot();
+    let restored_record = manager_device_snapshot(
+        manager_user_snapshot(
+            &restored_snapshot,
+            provisional_owner_pubkey(attacker.device_pubkey),
+        ),
+        attacker.device_pubkey,
+    );
+    assert_eq!(
+        restored_record.claimed_owner_pubkey,
+        Some(claimed_owner.owner_pubkey)
+    );
+    assert!(restored_record.active_session.is_some());
+    Ok(())
+}
+
+#[test]
+fn signed_app_keys_provenance_survives_restore_and_promotes_parked_claim() -> Result<()> {
+    let local = manager_device(55, 155);
+    let claimed_owner = manager_device(56, 156);
+    let device = manager_device(57, 157);
+    let (_, _, _, receiver_session) = direct_session_pair(157, 158, 1_810_001_400)?;
+    let mut manager = session_manager(&local);
+    manager.import_claimed_session_state(
+        claimed_owner.owner_pubkey,
+        device.device_pubkey,
+        receiver_session.state,
+        UnixSeconds(1_810_001_401),
+    );
+    manager.observe_peer_app_keys_event(
+        signed_app_keys_for(&claimed_owner, &[&device], 130),
+        UnixSeconds(130),
+    )?;
+
+    let restored = restore_manager(&manager.snapshot(), local.secret_key)?;
+    let restored_snapshot = restored.snapshot();
+    assert!(restored_snapshot
+        .users
+        .iter()
+        .all(|user| user.owner_pubkey != provisional_owner_pubkey(device.device_pubkey)));
+    let restored_record = manager_device_snapshot(
+        manager_user_snapshot(&restored_snapshot, claimed_owner.owner_pubkey),
+        device.device_pubkey,
+    );
+    assert!(restored_record.authorized);
+    assert_eq!(restored_record.claimed_owner_pubkey, None);
+    assert!(restored_record.active_session.is_some());
+    Ok(())
+}
+
+#[test]
+fn equal_time_signed_conflict_suspends_owner_attribution_across_restore() -> Result<()> {
+    let local = manager_device(58, 158);
+    let claimed_owner = manager_device(59, 159);
+    let device = manager_device(60, 160);
+    let (_, _, mut sender_session, receiver_session) =
+        direct_session_pair(160, 161, 1_810_001_500)?;
+    let mut manager = session_manager(&local);
+    manager.import_claimed_session_state(
+        claimed_owner.owner_pubkey,
+        device.device_pubkey,
+        receiver_session.state,
+        UnixSeconds(1_810_001_501),
+    );
+
+    manager.observe_peer_app_keys_event(
+        signed_app_keys_for(&claimed_owner, &[&device], 140),
+        UnixSeconds(140),
+    )?;
+    assert!(
+        manager_device_snapshot(
+            manager_user_snapshot(&manager.snapshot(), claimed_owner.owner_pubkey),
+            device.device_pubkey,
+        )
+        .authorized
+    );
+
+    manager.observe_peer_app_keys_event(
+        signed_app_keys_for(&claimed_owner, &[], 140),
+        UnixSeconds(140),
+    )?;
+    let conflicted = manager.snapshot();
+    assert_eq!(conflicted.verified_peer_app_keys_events.len(), 2);
+    assert!(
+        !manager_device_snapshot(
+            manager_user_snapshot(&conflicted, claimed_owner.owner_pubkey),
+            device.device_pubkey,
+        )
+        .authorized
+    );
+
+    let mut restored = restore_manager(&conflicted, local.secret_key)?;
+    let message = send_text(
+        &mut sender_session,
+        &mut context(27, 1_810_001_502),
+        "ambiguous-owner",
+    )?;
+    assert!(restored
+        .receive(
+            &mut context(28, 1_810_001_503),
+            claimed_owner.owner_pubkey,
+            &message.incoming,
+        )?
+        .is_none());
+    Ok(())
+}
+
+#[test]
 fn tampered_delivery_does_not_corrupt_receiver_state() -> Result<()> {
     let alice = manager_device(15, 151);
     let bob = manager_device(16, 161);
@@ -358,8 +697,10 @@ fn tampered_delivery_does_not_corrupt_receiver_state() -> Result<()> {
     let mut alice_manager = session_manager(&alice);
     let mut bob_manager = session_manager(&bob);
 
-    alice_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 80));
-    bob_manager.observe_peer_roster(alice.owner_pubkey, roster_for(&[&alice], 80));
+    alice_manager
+        .observe_peer_app_keys_event(signed_app_keys_for(&bob, &[&bob], 80), UnixSeconds(80))?;
+    bob_manager
+        .observe_peer_app_keys_event(signed_app_keys_for(&alice, &[&alice], 80), UnixSeconds(80))?;
     alice_manager.observe_device_invite(
         bob.owner_pubkey,
         manager_public_device_invite(&mut bob_manager, &bob, 80, 1_810_000_600)?,

--- a/rust/crates/nostr-double-ratchet/tests/session_manager_sesame_basic.rs
+++ b/rust/crates/nostr-double-ratchet/tests/session_manager_sesame_basic.rs
@@ -5,8 +5,9 @@ use nostr_double_ratchet::{
 };
 use support::{
     context, manager_device, manager_device_snapshot, manager_observe_invite_response,
-    manager_public_device_invite, manager_receive_delivery, manager_user_snapshot, payload_text,
-    prepared_targets, provisional_owner_pubkey, restore_manager, roster_for, session_manager,
+    manager_public_device_invite, manager_receive_delivery, manager_user_snapshot,
+    observe_signed_peer_app_keys, payload_text, prepared_targets, provisional_owner_pubkey,
+    restore_manager, roster_for, session_manager, signed_app_keys_for,
 };
 
 fn assert_gap(prepared: &nostr_double_ratchet::PreparedSend, expected: RelayGap) {
@@ -94,7 +95,7 @@ fn invite_observed_before_roster_becomes_usable_after_authorization() -> Result<
         },
     );
 
-    alice_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 12));
+    observe_signed_peer_app_keys(&mut alice_manager, &bob, &[&bob], 12)?;
     let mut send_ctx = context(12, 1_800_000_102);
     let after_auth =
         alice_manager.prepare_send(&mut send_ctx, bob.owner_pubkey, b"usable".to_vec())?;
@@ -123,7 +124,7 @@ fn prepare_send_fans_out_to_recipient_devices_and_local_siblings() -> Result<()>
         manager_public_device_invite(&mut alice2_manager, &alice2, 20, 1_800_000_200)?,
     )?;
 
-    alice_manager.observe_peer_roster(bob1.owner_pubkey, roster_for(&[&bob1, &bob2], 21));
+    observe_signed_peer_app_keys(&mut alice_manager, &bob1, &[&bob1, &bob2], 21)?;
     alice_manager.observe_device_invite(
         bob1.owner_pubkey,
         manager_public_device_invite(&mut bob1_manager, &bob1, 21, 1_800_000_201)?,
@@ -156,7 +157,7 @@ fn prepare_send_bootstraps_from_public_invite_and_returns_invite_response() -> R
     let mut alice_manager = session_manager(&alice);
     let mut bob_manager = session_manager(&bob);
 
-    alice_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 30));
+    observe_signed_peer_app_keys(&mut alice_manager, &bob, &[&bob], 30)?;
     alice_manager.observe_device_invite(
         bob.owner_pubkey,
         manager_public_device_invite(&mut bob_manager, &bob, 30, 1_800_000_300)?,
@@ -168,7 +169,7 @@ fn prepare_send_bootstraps_from_public_invite_and_returns_invite_response() -> R
     assert_eq!(prepared.deliveries.len(), 1);
     assert_eq!(prepared.invite_responses.len(), 1);
 
-    bob_manager.observe_peer_roster(alice.owner_pubkey, roster_for(&[&alice], 29));
+    observe_signed_peer_app_keys(&mut bob_manager, &alice, &[&alice], 29)?;
     let mut observe_ctx = context(32, 1_800_000_302);
     let observed = manager_observe_invite_response(
         &mut bob_manager,
@@ -190,15 +191,15 @@ fn prepare_send_bootstraps_from_public_invite_and_returns_invite_response() -> R
 }
 
 #[test]
-fn removed_device_is_excluded_from_send_but_can_still_decrypt_while_stale() -> Result<()> {
+fn removed_device_is_excluded_from_send_and_receive_immediately() -> Result<()> {
     let alice = manager_device(9, 91);
     let bob = manager_device(10, 101);
 
     let mut alice_manager = session_manager(&alice);
     let mut bob_manager = session_manager(&bob);
 
-    alice_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 40));
-    bob_manager.observe_peer_roster(alice.owner_pubkey, roster_for(&[&alice], 40));
+    observe_signed_peer_app_keys(&mut alice_manager, &bob, &[&bob], 40)?;
+    observe_signed_peer_app_keys(&mut bob_manager, &alice, &[&alice], 40)?;
     alice_manager.observe_device_invite(
         bob.owner_pubkey,
         manager_public_device_invite(&mut bob_manager, &bob, 41, 1_800_000_401)?,
@@ -229,7 +230,7 @@ fn removed_device_is_excluded_from_send_but_can_still_decrypt_while_stale() -> R
     let delayed =
         bob_manager.prepare_send(&mut bob_send_ctx, alice.owner_pubkey, b"late".to_vec())?;
 
-    alice_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[], 50));
+    observe_signed_peer_app_keys(&mut alice_manager, &bob, &[], 50)?;
     let mut after_removal_ctx = context(47, 1_800_000_407);
     let after_removal =
         alice_manager.prepare_send(&mut after_removal_ctx, bob.owner_pubkey, b"after".to_vec())?;
@@ -241,9 +242,8 @@ fn removed_device_is_excluded_from_send_but_can_still_decrypt_while_stale() -> R
         &mut receive_ctx,
         bob.owner_pubkey,
         &delayed.deliveries[0],
-    )?
-    .expect("stale device should still decrypt before prune");
-    assert_eq!(payload_text(&received.payload), "late");
+    )?;
+    assert!(received.is_none());
     Ok(())
 }
 
@@ -255,8 +255,8 @@ fn snapshot_roundtrip_preserves_established_active_sessions_without_new_bootstra
     let mut alice_manager = session_manager(&alice);
     let mut bob_manager = session_manager(&bob);
 
-    alice_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 60));
-    bob_manager.observe_peer_roster(alice.owner_pubkey, roster_for(&[&alice], 60));
+    observe_signed_peer_app_keys(&mut alice_manager, &bob, &[&bob], 60)?;
+    observe_signed_peer_app_keys(&mut bob_manager, &alice, &[&alice], 60)?;
     alice_manager.observe_device_invite(
         bob.owner_pubkey,
         manager_public_device_invite(&mut bob_manager, &bob, 60, 1_800_000_500)?,
@@ -315,7 +315,7 @@ fn peer_device_added_after_conversation_bootstraps_only_new_device() -> Result<(
     let mut bob1_manager = session_manager(&bob1);
     let mut bob2_manager = session_manager(&bob2);
 
-    alice_manager.observe_peer_roster(bob1.owner_pubkey, roster_for(&[&bob1], 70));
+    observe_signed_peer_app_keys(&mut alice_manager, &bob1, &[&bob1], 70)?;
     alice_manager.observe_device_invite(
         bob1.owner_pubkey,
         manager_public_device_invite(&mut bob1_manager, &bob1, 70, 1_800_000_600)?,
@@ -325,7 +325,7 @@ fn peer_device_added_after_conversation_bootstraps_only_new_device() -> Result<(
     let first = alice_manager.prepare_send(&mut boot_ctx, bob1.owner_pubkey, b"first".to_vec())?;
     assert_eq!(first.invite_responses.len(), 1);
 
-    alice_manager.observe_peer_roster(bob1.owner_pubkey, roster_for(&[&bob1, &bob2], 72));
+    observe_signed_peer_app_keys(&mut alice_manager, &bob1, &[&bob1, &bob2], 72)?;
     alice_manager.observe_device_invite(
         bob2.owner_pubkey,
         manager_public_device_invite(&mut bob2_manager, &bob2, 72, 1_800_000_602)?,
@@ -345,7 +345,7 @@ fn newer_public_invite_supersedes_older_one() -> Result<()> {
     let bob = manager_device(16, 161);
     let mut manager = session_manager(&alice);
 
-    manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 80));
+    observe_signed_peer_app_keys(&mut manager, &bob, &[&bob], 80)?;
 
     let newer = support::custom_public_device_invite(&bob, 80, 1_800_000_700)?;
     let older = support::custom_public_device_invite(&bob, 81, 1_800_000_699)?;
@@ -375,7 +375,7 @@ fn verified_owner_claim_migrates_session_to_claimed_owner() -> Result<()> {
     let mut alice_manager = session_manager(&alice);
     let mut bob_manager = session_manager(&bob);
 
-    bob_manager.observe_peer_roster(alice.owner_pubkey, roster_for(&[&alice], 82));
+    observe_signed_peer_app_keys(&mut bob_manager, &alice, &[&alice], 82)?;
     bob_manager.observe_device_invite(
         alice.owner_pubkey,
         manager_public_device_invite(&mut alice_manager, &alice, 82, 1_800_000_820)?,
@@ -397,7 +397,7 @@ fn verified_owner_claim_migrates_session_to_claimed_owner() -> Result<()> {
         provisional_owner_pubkey(bob.device_pubkey)
     );
 
-    alice_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 83));
+    observe_signed_peer_app_keys(&mut alice_manager, &bob, &[&bob], 83)?;
 
     let snapshot = alice_manager.snapshot();
     let verified_user = manager_user_snapshot(&snapshot, bob.owner_pubkey);
@@ -436,7 +436,7 @@ fn verified_roster_migrates_ownerless_provisional_invite_record() -> Result<()> 
     let provisional_device = manager_device_snapshot(provisional_user, bob.device_pubkey);
     assert!(provisional_device.public_invite.is_some());
 
-    alice_manager.observe_peer_roster(bob.owner_pubkey, roster_for(&[&bob], 86));
+    observe_signed_peer_app_keys(&mut alice_manager, &bob, &[&bob], 86)?;
 
     let snapshot = alice_manager.snapshot();
     let verified_user = manager_user_snapshot(&snapshot, bob.owner_pubkey);
@@ -459,10 +459,11 @@ fn snapshot_is_deterministic_for_users_devices_and_sessions() -> Result<()> {
     let mut right = session_manager(&alice1);
     let mut alice2_manager = session_manager(&alice2);
     let mut bob1_manager = session_manager(&bob1);
+    let bob_app_keys = signed_app_keys_for(&bob1, &[&bob1], 91);
 
     for manager in [&mut left, &mut right] {
         manager.apply_local_roster(roster_for(&[&alice1, &alice2], 90));
-        manager.observe_peer_roster(bob1.owner_pubkey, roster_for(&[&bob1], 91));
+        manager.observe_peer_app_keys_event(bob_app_keys.clone(), UnixSeconds(91))?;
         manager.observe_device_invite(
             alice1.owner_pubkey,
             manager_public_device_invite(&mut alice2_manager, &alice2, 90, 1_800_000_800)?,

--- a/rust/crates/nostr-double-ratchet/tests/support/mod.rs
+++ b/rust/crates/nostr-double-ratchet/tests/support/mod.rs
@@ -7,10 +7,11 @@ use nostr::{
 };
 use nostr_double_ratchet::wire as codec;
 use nostr_double_ratchet::{
-    AuthorizedDevice, Delivery, DevicePubkey, DeviceRecordSnapshot, DeviceRoster, Invite,
-    InviteResponse, InviteResponseEnvelope, MessageEnvelope, OwnerPubkey, PreparedSend,
-    ProcessedInviteResponse, ProtocolContext, ReceivedMessage, Result, RosterSnapshotDecision,
-    Session, SessionManager, SessionManagerSnapshot, SessionState, UnixSeconds, UserRecordSnapshot,
+    AppKeys, AuthorizedDevice, Delivery, DeviceEntry, DevicePubkey, DeviceRecordSnapshot,
+    DeviceRoster, Invite, InviteResponse, InviteResponseEnvelope, MessageEnvelope, OwnerPubkey,
+    PreparedSend, ProcessedInviteResponse, ProtocolContext, ReceivedMessage, Result,
+    RosterSnapshotDecision, Session, SessionManager, SessionManagerSnapshot, SessionState,
+    UnixSeconds, UserRecordSnapshot,
 };
 use rand::{rngs::StdRng, CryptoRng, RngCore, SeedableRng};
 use serde::Serialize;
@@ -131,6 +132,34 @@ pub fn roster_for(devices: &[&ManagerDevice], created_at: u64) -> DeviceRoster {
             .iter()
             .map(|device| AuthorizedDevice::new(device.device_pubkey, UnixSeconds(created_at)))
             .collect(),
+    )
+}
+
+pub fn signed_app_keys_for(
+    owner: &ManagerDevice,
+    devices: &[&ManagerDevice],
+    created_at: u64,
+) -> Event {
+    AppKeys::new(
+        devices
+            .iter()
+            .map(|device| DeviceEntry::new(device.device_pubkey.to_nostr().unwrap(), created_at))
+            .collect(),
+    )
+    .get_event_at(owner.owner_keys.public_key(), created_at)
+    .sign_with_keys(&owner.owner_keys)
+    .expect("signed AppKeys")
+}
+
+pub fn observe_signed_peer_app_keys(
+    manager: &mut SessionManager,
+    owner: &ManagerDevice,
+    devices: &[&ManagerDevice],
+    created_at: u64,
+) -> Result<bool> {
+    manager.observe_peer_app_keys_event(
+        signed_app_keys_for(owner, devices, created_at),
+        UnixSeconds(created_at),
     )
 }
 
@@ -583,13 +612,6 @@ pub trait SessionManagerCompatExt {
         observed_at: UnixSeconds,
     ) -> RosterSnapshotDecision;
 
-    fn observe_peer_app_keys(
-        &mut self,
-        owner_pubkey: OwnerPubkey,
-        roster: DeviceRoster,
-        observed_at: UnixSeconds,
-    ) -> RosterSnapshotDecision;
-
     fn prepare_send_text<R>(
         &mut self,
         ctx: &mut ProtocolContext<'_, R>,
@@ -618,15 +640,6 @@ impl SessionManagerCompatExt for SessionManager {
         _observed_at: UnixSeconds,
     ) -> RosterSnapshotDecision {
         self.apply_local_roster(roster)
-    }
-
-    fn observe_peer_app_keys(
-        &mut self,
-        owner_pubkey: OwnerPubkey,
-        roster: DeviceRoster,
-        _observed_at: UnixSeconds,
-    ) -> RosterSnapshotDecision {
-        self.observe_peer_roster(owner_pubkey, roster)
     }
 
     fn prepare_send_text<R>(


### PR DESCRIPTION
## Summary

- treat invite owner fields as lookup hints rather than authorization
- require an exact owner-signed AppKeys event to authorize a distinct invite device
- retain equal-time conflicting AppKeys heads so membership checks fail closed
- persist exact signed AppKeys evidence in TypeScript user records and retry deferred invite responses after normal AppKeys ingestion
- keep single-device invites working when the owner and authenticated device keys are the same

## Root cause

Invite cryptography authenticated the device key, but a distinct claimed owner could be used for attribution before proving that the owner had authorized that device. An attacker could therefore generate a device key, claim another user's owner key, and be treated as that owner while the real AppKeys roster was unavailable.

## Impact

For an owner claim `O` and cryptographically authenticated device `D`:

- `O = D` remains self-authenticating
- `O != D` is accepted only when the newest exact event signed by `O` contains `D`
- missing or conflicting evidence does not create an owner-attributed session
- an owner-signed roster that excludes `D` rejects the claim

## Validation

- `cargo test --workspace -q`
- `pnpm run test:once` — 44 files, 431 tests
- `pnpm exec tsc --noEmit`
